### PR TITLE
CI: bump JDK to temurin@17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.x, 2.13.x, 3.3.x]
-        java: [zulu@8]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -32,12 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (zulu@8)
-        if: matrix.java == 'zulu@8'
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
-          distribution: zulu
-          java-version: 8
+          distribution: temurin
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt
@@ -66,7 +66,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.3.8]
-        java: [zulu@8]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -74,12 +74,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (zulu@8)
-        if: matrix.java == 'zulu@8'
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
-          distribution: zulu
-          java-version: 8
+          distribution: temurin
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,9 +8,9 @@ pull_request_rules:
       - or:
           - author=scala-steward
           - author=nafg-scala-steward[bot]
-      - check-success=Build and Test (ubuntu-latest, 2.12.x, zulu@8)
-      - check-success=Build and Test (ubuntu-latest, 2.13.x, zulu@8)
-      - check-success=Build and Test (ubuntu-latest, 3.3.x, zulu@8)
+      - check-success=Build and Test (ubuntu-latest, 2.12.x, temurin@17)
+      - check-success=Build and Test (ubuntu-latest, 2.13.x, temurin@17)
+      - check-success=Build and Test (ubuntu-latest, 3.3.x, temurin@17)
     actions:
         queue:
             name: default

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ ThisBuild / scalaVersion := {
     versions.last
 }
 ThisBuild / organization := "io.github.nafg.simpleivr"
+ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 
 def ScalaTest = "org.scalatest" %% "scalatest" % "3.2.20"
 


### PR DESCRIPTION
sbt 2.x requires JDK 17 or above, so CI on `zulu@8` fails with:

```
[error] sbt 2.x requires JDK 17 or above, but you have JDK 8
```

This blocks scala-steward's #397 ("Update sbt to 2.0.6") and any future sbt-2 bump.

Sets `ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))` and regenerates the sbt-github-actions output, which also updates `.mergify.yml`'s check-success names to the new `temurin@17` label.

Verified locally on Temurin 17: `sbt "+test"` passes on 2.12.20 / 2.13.16 / 3.3.6, and `sbt githubWorkflowCheck` passes with no diff needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated build and publishing workflows to use Temurin JDK 17.
  * Updated automated merge checks across supported Scala versions to validate against Java 17.
  * Standardized the project’s configured GitHub Actions Java version on JDK 17.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->